### PR TITLE
Release 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ h("div", {height: "2000px"}, "TALL")
 ```
 
 
+### Preserving input state
+
+Values set by BDC will take priority over previous changes by the user.
+
+Internally, BDC uses DOM property assignment wherever possible, only falling
+back to `setAttribute` if the element doesn't export the property of interest.
+This [article](https://javascript.info/dom-attributes-and-properties) is a good
+resource if you would like to learn more about the difference.
+
+Applications built with BDC are required to listen for changes to input state
+and update the node DOM to match.  Failing to do so will result in the element
+DOM state being replaced the next time that `clobber` is called.
+
+It is very often acceptible to be lazy about this.  If you can be certain that
+no other events will trigger a clobber, listening for the `onchange` event
+instead of `oninput` can be a reasonable optimisation.
+
+
 ### Event Handlers
 
 Attributes prefixed with `on` are treated as event handlers.
@@ -158,6 +176,7 @@ preserve the current focus.
 
 
 ### CSS
+
 The `style` attribute is a string, as most users would expect, but is
 implemented as a special case and therefore deserves mention.
 
@@ -165,24 +184,6 @@ While most attributes have fairly straightforward DOM property counterparts,
 `style` us parsed and exposed as a [CSSStyleDeclarationProperty](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration).
 Rather than expect users to construct on of these for each render, BDC will set
 the existing objects `cssText` property to match what the user passes.
-
-
-### Preserving input state
-
-Values set by BDC will take priority over previous changes by the user.
-
-Internally, BDC uses DOM property assignment wherever possible, only falling
-back to `setAttribute` if the element doesn't export the property of interest.
-This [article](https://javascript.info/dom-attributes-and-properties) is a good
-resource if you would like to learn more about the difference.
-
-Applications built with BDC are required to listen for changes to input state
-and update the node DOM to match.  Failing to do so will result in the element
-DOM state being replaced the next time that `clobber` is called.
-
-It is very often acceptible to be lazy about this.  If you can be certain that
-no other events will trigger a clobber, listening for the `onchange` event
-instead of `oninput` can be a reasonable optimisation.
 
 
 ### Web Components

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ BDC does not construct a virtual DOM, preferring to diff directly against
 the real thing.
 This results in a smaller, simpler, and probably much slower library.
 
+It is a good choice for small projects that are too dynamic to complete easily
+using vanilla javascript, but where a complex build setup and tens of megabytes
+of compiled code would be overkill.
+It is a bad choice for pages that must repeatedly re-render a large amount of
+dynamic data, and for more complicated applications where you may benefit from
+the larger ecosystem around other libraries.
+
 BDC is currently under active development.  The API is unlikely to change
 significantly before 1.0, but there may still be bugs that need to be ironed
 out.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Ben's DOM Clobberer
 
 [![Build Status](https://travis-ci.org/bwhmather/bdc-js.svg?branch=develop)](https://travis-ci.org/bwhmather/bdc-js)
 
-BDC is a tiny javascript library for updating the html DOM to match a
-javascript description.
+Ben's DOM Clobberer (BDC) is a tiny javascript library for updating the html DOM
+to match a javascript description.
 
 It weighs less that 1KiB when gzipped, and presents a simple API that makes it
 easy to describe HTML without needing to resort to JSX.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ BDC does not construct a virtual DOM, preferring to diff directly against
 the real thing.
 This results in a smaller, simpler, and probably much slower library.
 
-It is a good choice for small projects that are too dynamic to complete easily
+BDC is a good choice for small projects that are too dynamic to complete easily
 using vanilla javascript, but where a complex build setup and tens of megabytes
 of compiled code would be overkill.
 It is a bad choice for pages that must repeatedly re-render a large amount of

--- a/README.md
+++ b/README.md
@@ -165,9 +165,20 @@ the DOM.  BDC requires you to set it as a string.
 
 ### Preserving input state
 
+Values set by BDC will take priority over previous changes by the user.
+
+Internally, BDC uses DOM property assignment wherever possible, only falling
+back to `setAttribute` if the element doesn't export the property of interest.
+This [article](https://javascript.info/dom-attributes-and-properties) is a good
+resource if you would like to learn more about the difference.
+
 Applications built with BDC are required to listen for changes to input state
 and update the node DOM to match.  Failing to do so will result in the element
 DOM state being replaced the next time that `clobber` is called.
+
+It is very often acceptible to be lazy about this.  If you can be certain that
+no other events will trigger a clobber, listening for the `onchange` event
+instead of `oninput` can be a reasonable optimisation.
 
 
 ### Web Components

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Both will return a static tree that maps to the following html:
 ```
 
 Attributes can be set by passing an object as the second argument to `h`.
-There is not way to set attributes on the root element passed to clobber.
+There is no way to set attributes on the root element passed to clobber.
 
 This example will map to a `div` with `width` set to `"200px"`:
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ clobber(
 );
 ```
 
-When run, this example will update the body of the current document to contain
-the following HTML:
+When run, this example will update the DOM of the current document to be match
+what would result from the following HTML:
 
 ```html
 <marquee>

--- a/README.md
+++ b/README.md
@@ -158,9 +158,13 @@ preserve the current focus.
 
 
 ### CSS
+The `style` attribute is a string, as most users would expect, but is
+implemented as a special case and therefore deserves mention.
 
-The style attribute is a string in HTML but is decoded to a data-structure in
-the DOM.  BDC requires you to set it as a string.
+While most attributes have fairly straightforward DOM property counterparts,
+`style` us parsed and exposed as a [CSSStyleDeclarationProperty](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration).
+Rather than expect users to construct on of these for each render, BDC will set
+the existing objects `cssText` property to match what the user passes.
 
 
 ### Preserving input state

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -15,7 +15,6 @@
     </footer>
 
     <script src="node_modules/todomvc-common/base.js"></script>
-    <script src="node_modules/bdc/dist/bdc.js"></script>
     <script src="dist/app.min.js"></script>
     <script>
       app.install(document.getElementById("root"));

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -12,6 +12,7 @@
     "rollup": "^2.2.0",
     "rollup-plugin-terser": "^5.3.0",
     "rollup-plugin-typescript2": "^0.27.0",
+    "@rollup/plugin-node-resolve": "7.1.3",
     "tslint": "^6.1.0",
     "typescript": "^3.8.3"
   },

--- a/examples/todomvc/rollup.config.js
+++ b/examples/todomvc/rollup.config.js
@@ -1,5 +1,7 @@
 import typescript from 'rollup-plugin-typescript2';
+import resolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
+
 
 
 export default [
@@ -9,6 +11,7 @@ export default [
       typescript({
         abortOnError: false,
       }),
+      resolve(),
       terser(),
     ],
     output: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Ben's DOM Clobberer",
   "license": "MIT",
   "keywords": [],
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Ben Mather <bwhmather@bwhmather.com> (bwhmather.com)",
   "homepage": "https://github.com/bwhmather/bdc-js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "main": "dist/bdc.umd.js",
   "module": "dist/bdc.mjs",
+  "jsnext:main": "dist/bdc.mjs",
   "types": "dist/types/index.d.ts",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
In addition to improving the documentation, adds `"jsnext:main"` entry to `package.json` to enable use with rollup.